### PR TITLE
Fix: Sanitize filenames to prevent path traversal

### DIFF
--- a/src/transports/FileTransport.ts
+++ b/src/transports/FileTransport.ts
@@ -116,6 +116,10 @@ export class FileTransport implements Transport {
     for (let i = this.maxFiles - 1; i < files.length; i++) {
       const file = files[i];
       if (file) {
+        // Validate filename
+        if (file.includes('../') || file.includes('..\\') || file.startsWith('..')) {
+          continue;
+        }
         const fileToDelete = path.join(dir, file);
         fs.unlinkSync(fileToDelete);
       }
@@ -149,6 +153,14 @@ export class FileTransport implements Transport {
         }
 
         for (const file of toDelete) {
+          // Validate Filename
+          if (file.includes('../') || file.includes('..\\') || file.startsWith('..')) {
+            completed++;
+            if (completed === toDelete.length) {
+              resolve();
+            }
+            continue;
+          }
           const fileToDelete = path.join(dir, file);
           fs.unlink(fileToDelete, (unlinkErr) => {
             completed++;


### PR DESCRIPTION
Adds validation to ensure that filenames do not contain path traversal sequences such as `../` or start with `..`. This prevents deletion of files outside the intended log directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced safety during file cleanup operations by preventing deletion of files containing path traversal patterns or parent-directory references, protecting against accidental removal of critical system files during rotation cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->