### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Dev-Dami/tini-log/security/code-scanning/2](https://github.com/Dev-Dami/tini-log/security/code-scanning/2)

To fix the problem, add a `permissions` block that grants the minimum required privileges for the workflow and each job. In this case:
- At the root workflow level, set `permissions: contents: read` to grant read-only permissions by default.
- For the `publish-npm` job (which publishes to npm registry), elevate permissions only if needed for pushing releases—in most npm publish scenarios, `contents: read` is sufficient because publishing uses an npm token. But if the workflow interacts with GitHub Packages (not npmjs.com), it may require `contents: write`. If only npmjs.com, stay with `read`.
- The workflow publishes to npmjs.org, not GitHub Packages, so no elevated `contents` permission is required—leave all jobs at `contents: read`.
- Add the following at the top-level of the workflow (just after `name:`):  
  ```yaml
  permissions:
    contents: read
  ```
- No further method, import, or new dependency is needed; only the workflow YAML changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->