### PR TITLE
docs(examples): add custom transport logger example

### DIFF
--- a/examples/custom-transport.ts
+++ b/examples/custom-transport.ts
@@ -1,33 +1,20 @@
 import { Logger } from "../src";
-/**
- * Example: Custom Transport
- *
- * Demonstrates how to plug in a custom transport
- * for sending logs to external systems.
- */
 
-/**
- * Custom transport that sends logs somewhere else
- * (file, DB, external service, etc.)
- */
 const customTransport = {
-  log(level: string, message: string, meta?: Record<string, unknown>) {
-    // Example: send to external service
-    console.log("[CUSTOM TRANSPORT]", {
-      level,
-      message,
-      meta,
-      timestamp: new Date().toISOString(),
-    });
+  write(data: any, formatter: any) {
+    const formatted = formatter.format(data);
+
+    // Example: send logs to an external service
+    console.log("[CUSTOM TRANSPORT]", formatted);
   },
 };
 
-const prefixedLogger = new Logger({
+const logger = new Logger({
   level: "info",
   prefix: "[WebApp]",
   timestamp: true,
+  transports: [customTransport],
 });
 
-prefixedLogger.info("Application started");
-prefixedLogger.warn("Low memory warning");
-prefixedLogger.error("Something went wrong");
+logger.info("Hello from custom transport", { userId: 42 });
+logger.warn("This is a warning");


### PR DESCRIPTION
## Description
## What this PR does
Adds a new example demonstrating how to create and use a custom transport with the logger.

## Why
There was no example showing how to extend logging using custom transports, which can help users adapt the library to their own needs.

### Scope
- Example only
- No dependency or core code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new example showing how to integrate and configure a custom logging transport. The example walks through setup of logging levels, message prefixes, and timestamps, and demonstrates emitting info and warning messages so you can see formatted log output and verify the transport integration in a simple, copyable example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->