### PR TITLE
test: cover boring log level behavior

### DIFF
--- a/src/utils/ColorUtil.ts
+++ b/src/utils/ColorUtil.ts
@@ -45,6 +45,10 @@ export class ColorUtil {
       return text;
     }
 
+    if (color === "boring") {
+      return text;
+    }
+
     const colorCode = ColorUtil.ANSI_COLORS[color] || ColorUtil.ANSI_COLORS.reset;
     return `${colorCode}${text}${ColorUtil.ANSI_COLORS.reset}`;
   }

--- a/tests/core/Logger.test.ts
+++ b/tests/core/Logger.test.ts
@@ -72,10 +72,11 @@ describe("Logger - Boring Log Level", () => {
 
       logger.boring("Plain boring message");
 
+      const ansiEscapeRegex = new RegExp(String.raw`\x1b\[[0-9;]*m`);
       expect(formattingTransport.outputs).toHaveLength(1);
       expect(formattingTransport.outputs[0]).toContain("[BORING]");
       expect(formattingTransport.outputs[0]).toContain("Plain boring message");
-      expect(formattingTransport.outputs[0]).not.toMatch(/\x1b\[[0-9;]*m/);
+      expect(formattingTransport.outputs[0]).not.toMatch(ansiEscapeRegex);
     } finally {
       if (previousForceColor === undefined) {
         delete process.env.FORCE_COLOR;

--- a/tests/core/Logger.test.ts
+++ b/tests/core/Logger.test.ts
@@ -12,6 +12,80 @@ class MockTransport implements Transport {
   }
 }
 
+class FormattingTransport implements Transport {
+  public outputs: string[] = [];
+  write(data: LogData, formatter: Formatter): void {
+    this.outputs.push(formatter.format(data));
+  }
+}
+
+describe("Logger - Boring Log Level", () => {
+  let mockTransport: MockTransport;
+
+  beforeEach(() => {
+    mockTransport = new MockTransport();
+  });
+
+  test("logger.boring() should emit boring logs at the boring threshold", () => {
+    const logger = new Logger({
+      level: "boring",
+      transports: [mockTransport],
+    });
+
+    logger.boring("Boring message");
+
+    expect(mockTransport.logs).toHaveLength(1);
+    expect(mockTransport.logs[0]).toMatchObject({
+      level: "boring",
+      message: "Boring message",
+    });
+  });
+
+  test("logger.boring() should not emit when the threshold is debug", () => {
+    const logger = new Logger({
+      level: "debug",
+      transports: [mockTransport],
+    });
+
+    logger.boring("Hidden boring message");
+    logger.debug("Visible debug message");
+
+    expect(mockTransport.logs).toHaveLength(1);
+    expect(mockTransport.logs[0]).toMatchObject({
+      level: "debug",
+      message: "Visible debug message",
+    });
+  });
+
+  test("boring logs should format without ANSI color codes by default", () => {
+    const previousForceColor = process.env.FORCE_COLOR;
+    process.env.FORCE_COLOR = "1";
+
+    try {
+      const formattingTransport = new FormattingTransport();
+      const logger = new Logger({
+        level: "boring",
+        colorize: true,
+        timestamp: false,
+        transports: [formattingTransport],
+      });
+
+      logger.boring("Plain boring message");
+
+      expect(formattingTransport.outputs).toHaveLength(1);
+      expect(formattingTransport.outputs[0]).toContain("[BORING]");
+      expect(formattingTransport.outputs[0]).toContain("Plain boring message");
+      expect(formattingTransport.outputs[0]).not.toMatch(/\x1b\[[0-9;]*m/);
+    } finally {
+      if (previousForceColor === undefined) {
+        delete process.env.FORCE_COLOR;
+      } else {
+        process.env.FORCE_COLOR = previousForceColor;
+      }
+    }
+  });
+});
+
 describe("Logger - Child Loggers", () => {
   let parentLogger: Logger;
   let mockTransport: MockTransport;


### PR DESCRIPTION
## Summary
- add coverage for logger.boring() at the boring and debug thresholds
- verify boring output stays free of ANSI color codes when color output is forced
- keep the default boring color behavior aligned with the documented uncolored level

## Verification
- npm test -- --runInBand tests/core/Logger.test.ts
- npm test -- --runInBand
- npm run build
- npm run lint
- git diff --check

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for “boring” log messages so they remain plain text without any color/ANSI formatting.
  * Updated logging behavior so boring messages respect the active log level and are suppressed when a more verbose level is enabled.
  * Confirmed boring log output shows the expected `[BORING]` label and message without color codes.

* **Tests**
  * Added coverage for boring log emission, suppression by log level, and default formatting behavior (including ANSI color expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->